### PR TITLE
Add an example to cmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 *.tar
 
 dist
+
+# example build files
+build
+sdkconfig
+managed_components
+dependencies.lock

--- a/cmp/README.md
+++ b/cmp/README.md
@@ -6,7 +6,7 @@ To use it with your ESP-IDF project make sure that [the component manager](https
 
 ```yaml
 dependencies:
-  example/cmp: "~3.3.3"
+  example/cmp: "^3.3.3"
 ```
 
 ## API

--- a/cmp/changelog.md
+++ b/cmp/changelog.md
@@ -1,3 +1,7 @@
+## 3.3.8
+
+- Add example
+
 ## 3.3.7
 
 - Fix accidentally excluded header file

--- a/cmp/examples/cmp_ex/CMakeLists.txt
+++ b/cmp/examples/cmp_ex/CMakeLists.txt
@@ -1,0 +1,8 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(cmp_ex)

--- a/cmp/examples/cmp_ex/main/CMakeLists.txt
+++ b/cmp/examples/cmp_ex/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "cmp_ex.c"
+                    INCLUDE_DIRS ".")

--- a/cmp/examples/cmp_ex/main/cmp_ex.c
+++ b/cmp/examples/cmp_ex/main/cmp_ex.c
@@ -1,0 +1,6 @@
+#include "cmp.h"
+
+void app_main(void)
+{
+    cmp_hello();
+}

--- a/cmp/examples/cmp_ex/main/idf_component.yml
+++ b/cmp/examples/cmp_ex/main/idf_component.yml
@@ -1,0 +1,5 @@
+## IDF Component Manager Manifest File
+dependencies:
+  example/cmp:
+    version: "^3.3.7"
+    override_path: "../../.."

--- a/cmp/idf_component.yml
+++ b/cmp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.3.7"
+version: "3.3.8"
 description: This component is an example, to be used with the IDF component manager.
 url: https://github.com/espressif/example_components/tree/main/cmp
 dependencies:


### PR DESCRIPTION
Add an example to the component `cmp`. The example utilizes `override_path` feature of the component manager.